### PR TITLE
Update Bundle.js

### DIFF
--- a/lib/package/Bundle.js
+++ b/lib/package/Bundle.js
@@ -209,7 +209,8 @@ function processFileSystem(config, bundle, cb) {
 
   //only run for proxy or shared flow root
   if (!bundle.proxyRoot.endsWith(bundleName)) {
-    var folders = new FindFolder(bundleName);
+    var folderArray = new FindFolder(bundleName);
+    var folders = JSON.stringify(folderArray);
     //potentially have (apiproxy and target/apiproxy) or shared flow
     if (bundleName == bundleType.BundleType.APIPROXY && folders.includes("target/apiproxy")) {
       //we prefer the target bundle when we have both


### PR DESCRIPTION
Javascript .includes can't check the partial match of a variable in an array. For example if an array (testArray) has an element 'Hello World', testArray.includes('Hello') returns false, however testArray.includes('Hello World') returns true. That's why I have stringified the array to check the partial match.